### PR TITLE
Enable Prebuilds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "spring-petclinic-angular"]
+	path = spring-petclinic-angular
+	url = https://github.com/spring-petclinic/spring-petclinic-angular.git
+    ignore = dirty

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,14 +3,23 @@ image:
 
 tasks:
   - name: spring-petclinic-angular
-    before: cd /workspace && git clone https://github.com/spring-petclinic/spring-petclinic-angular.git && cd /workspace/spring-petclinic-angular
-    init: npm install --silent && npm run build --silent
+    init: |
+      cd /workspace/workshop-spring-reactive/spring-petclinic-angular
+      npm install --silent
+      npm run build --silent
     command: |
-      echo "export const environment = {production: false, REST_API_URL: '$(gp url 9966)/petclinic/api/'};" > /workspace/spring-petclinic-angular/src/environments/environment.ts 
+      cd /workspace/workshop-spring-reactive/spring-petclinic-angular
+      echo "export const environment = {production: false, REST_API_URL: '$(gp url 9966)/petclinic/api/'};" > /workspace/workshop-spring-reactive/spring-petclinic-angular/environment.ts 
       npm run start
+    env:
+      # suppress the "Would you like to share anonymous usage data with the Angular Team at Google under Google’s Privacy Policy" message.
+      NG_CLI_ANALYTICS: ci
   - name: spring-petclinic-reactive
-    init:  mvn clean package install && . setup.sh
-    command: mvn clean package install && java -jar target/spring-petclinic-reactive-1.0.0-SNAPSHOT.jar 
+    init: |
+      mvn clean package install
+    command: |
+      . setup.sh
+      java -jar target/spring-petclinic-reactive-1.0.0-SNAPSHOT.jar 
 
 ports:
   - port: 4200
@@ -24,12 +33,12 @@ ports:
 
 github:
   prebuilds:
-    master: false
-    branches: false
-    pullRequests: false
+    master: true
+    branches: true
+    pullRequests: true
     pullRequestsFromForks: false
-    addCheck: false
+    addCheck: true
     addComment: false
-    addBadge: false
+    addBadge: true
     addLabel: false
 

--- a/doc/LOCAL_README.md
+++ b/doc/LOCAL_README.md
@@ -89,7 +89,6 @@ To enable this tracing set the properties to `zipkin.enabled` to true in `applic
 **✅ Start the front end* : This REST API is meant to be used with the existing **[spring-petclinic-angular](https://github.com/spring-petclinic/spring-petclinic-angular)** user interface. To run the application please execute the following:
 
 ```bash
-git clone https://github.com/spring-petclinic/spring-petclinic-angular.git
 cd spring-petclinic-angular
 npm uninstall -g angular-cli @angular/cli
 npm cache clean


### PR DESCRIPTION
This PR...
* enables prebuilds in the .gitpod.yaml
* moves spring-petclinic-angular into a git-submodule,
  because this allows Gitpod to clone it during a prebuild.

With prebuilds, workshop participants don't need to wait for code to compile and for dependencies to be downloaded.

<a href="https://gitpod.io/#https://github.com/DataStax-Academy/workshop-spring-reactive/pull/1"><img src="https://gitpod.io/api/apps/github/pbs/github.com/DataStax-Academy/workshop-spring-reactive.git/c9d8a63fe343cac9ddc15bfe9d6ec915360c50d5.svg" /></a>

